### PR TITLE
Integrate planning statistics with benchmarking environment

### DIFF
--- a/src/main_tsp.cpp
+++ b/src/main_tsp.cpp
@@ -178,10 +178,17 @@ int main(int argc, char** argv) {
                                        elite_fraction, sample_count, check_points,
                                        gd_iterations, init_points, collision_weight, z_min);
 
-    Point end_pt = Utility::get_body_point<Point>(m, d, coll_body_name);
-    end_pt[2] += 0.8;
+    std::string start_body_name = "block_green/";
+    std::string end_body_name = "block_orange/";
+    Point end_pt = Utility::get_body_point<Point>(m, d, end_body_name);
+    // Point end_pt = Utility::get_body_point<Point>(m, d, coll_body_name);
+    // end_pt[2] += 0.8;
     Point start_pt;
-    start_pt << -0.5, 0.7, 0.8, 1.5708;
+    // start_pt << -0.5, 0.7, 0.8, 1.5708;
+    start_pt = Utility::get_body_point<Point>(m, d, start_body_name);
+
+    end_pt[2] += 0.02;
+    start_pt[2] += 0.02;
 
     // Initial Planning Attempt
     execute_planning_cycle(path_planner, start_pt, end_pt,

--- a/src/tsp_bindings.cpp
+++ b/src/tsp_bindings.cpp
@@ -77,6 +77,13 @@ PYBIND11_MODULE(_tsp, m) {
                        ", gradient_steps=" + std::to_string(pc.gradient_steps.size()) + ")";
             });
 
+    py::class_<PlanningStats>(m, "PlanningStats")
+            .def_readonly("planning_time_ms", &PlanningStats::planning_time_ms)
+            .def_readonly("successful_count", &PlanningStats::successful_count)
+            .def_readonly("failed_count", &PlanningStats::failed_count)
+            .def_readonly("is_iterative", &PlanningStats::is_iterative)
+            .def_readonly("gradient_descent_used", &PlanningStats::gradient_descent_used);
+
     // Bind Gradient class (for advanced users)
     py::class_<Gradient<4>>(m, "Gradient")
             .def(py::init<typename Gradient<4>::CostFunction, const Point&, const Point&>(),
@@ -198,6 +205,10 @@ PYBIND11_MODULE(_tsp, m) {
                  "Get minimum sampling limits for each dimension")
             .def("get_limits_max", &TaskSpacePlanner::get_limits_max,
                  "Get maximum sampling limits for each dimension")
+            .def("get_planning_stats", &TaskSpacePlanner::get_planning_stats,
+                 "Get statistics from last planning iteration")
+            .def("set_enable_gradient_descent", &TaskSpacePlanner::set_enable_gradient_descent,
+                 py::arg("enable"), "Enable or disable gradient descent refinement")
 
                     // Spline inspection methods
             .def("get_via_pts", &TaskSpacePlanner::get_via_pts,


### PR DESCRIPTION
## Summary
- Add PlanningStats tracking to record timing, candidate counts, iteration mode, and gradient-descent usage
- Expose planning stats retrieval and runtime gradient-descent toggling via Python bindings
- Remove large robocrane assets from repository

## Testing
- `pip install -e .` *(fails: Could not find scikit-build-core; proxy 403)*
- `python -m unittest discover -s sspp/tests -p "test_BSplines.py"` *(fails: ModuleNotFoundError: casadi)*
- `pip install casadi` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689edc4f2a78832d9ca9bfc9117ac61a